### PR TITLE
Fix: Populate expense account when updating an expense

### DIFF
--- a/components/tables/expensesTable.tsx
+++ b/components/tables/expensesTable.tsx
@@ -30,6 +30,7 @@ import Toast from "../shared/toasts/authToast";
 import { QueryClient, QueryClientProvider } from "react-query";
 
 type Expense = {
+  expense_account: number;
   created_at: Date;
   category: string;
   expense: string;
@@ -294,7 +295,7 @@ const Table = () => {
           <Controller
             name="accountID"
             control={control}
-            defaultValue={row.original.account_id}
+            defaultValue={row.original.expense_account}
             render={({ field }) => (
               <select
                 {...field}


### PR DESCRIPTION
# Populate the expense account when an expense is being updated

## Description

- 

## Motivation and Context



## How Has This Been Tested?



## Screenshots (if appropriate):

- N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
